### PR TITLE
Fix incorrect rule ordering

### DIFF
--- a/lib/index.scss
+++ b/lib/index.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap");
-
 @use "components";
 @use "tokens";
+
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap");


### PR DESCRIPTION
`@use` rules must be written before any other rules. The CSS fails to build otherwise.