### PR TITLE
Adjust typography values for utils compatibility

### DIFF
--- a/.changeset/red-meals-explode.md
+++ b/.changeset/red-meals-explode.md
@@ -1,0 +1,5 @@
+---
+"@destinygg/libstiny": patch
+---
+
+Fixed typography to be compatible with the utils for extracting fontsize and lineheight

--- a/lib/tokens/typography.scss
+++ b/lib/tokens/typography.scss
@@ -1,60 +1,62 @@
+@use "sass:list";
+
 $label: 700 0.75rem Inter;
 $label-letter-spacing: 0.1em;
 
-$display-600-regular: 400 4.5rem/4.5rem "Poppins";
-$display-600-medium: 500 4.5rem/4.5rem "Poppins";
-$display-600-semi-bold: 600 4.5rem/4.5rem "Poppins";
-$display-600-bold: 700 4.5rem/4.5rem "Poppins";
+$display-600-regular: 400 list.slash(4.5rem, 4.5rem) "Poppins";
+$display-600-medium: 500 list.slash(4.5rem, 4.5rem) "Poppins";
+$display-600-semi-bold: 600 list.slash(4.5rem, 4.5rem) "Poppins";
+$display-600-bold: 700 list.slash(4.5rem, 4.5rem) "Poppins";
 
-$display-500-regular: 400 3.75rem/3.75rem "Poppins";
-$display-500-medium: 500 3.75rem/3.75rem "Poppins";
-$display-500-semi-bold: 600 3.75rem/3.75rem "Poppins";
-$display-500-bold: 700 3.75rem/3.75rem "Poppins";
+$display-500-regular: 400 list.slash(3.75rem, 3.75rem) "Poppins";
+$display-500-medium: 500 list.slash(3.75rem, 3.75rem) "Poppins";
+$display-500-semi-bold: 600 list.slash(3.75rem, 3.75rem) "Poppins";
+$display-500-bold: 700 list.slash(3.75rem, 3.75rem) "Poppins";
 
-$display-400-regular: 400 3rem/3rem "Poppins";
-$display-400-medium: 500 3rem/3rem "Poppins";
-$display-400-semi-bold: 600 3rem/3rem "Poppins";
-$display-400-bold: 700 3rem/3rem "Poppins";
+$display-400-regular: 400 list.slash(3rem, 3rem) "Poppins";
+$display-400-medium: 500 list.slash(3rem, 3rem) "Poppins";
+$display-400-semi-bold: 600 list.slash(3rem, 3rem) "Poppins";
+$display-400-bold: 700 list.slash(3rem, 3rem) "Poppins";
 
-$display-300-regular: 400 2.25rem/2.25rem "Poppins";
-$display-300-medium: 500 2.25rem/2.25rem "Poppins";
-$display-300-semi-bold: 600 2.25rem/2.25rem "Poppins";
-$display-300-bold: 700 2.25rem/2.25rem "Poppins";
+$display-300-regular: 400 list.slash(2.25rem, 2.25rem) "Poppins";
+$display-300-medium: 500 list.slash(2.25rem, 2.25rem) "Poppins";
+$display-300-semi-bold: 600 list.slash(2.25rem, 2.25rem) "Poppins";
+$display-300-bold: 700 list.slash(2.25rem, 2.25rem) "Poppins";
 
-$display-200-regular: 400 1.88rem/1.88rem "Poppins";
-$display-200-medium: 500 1.88rem/1.88rem "Poppins";
-$display-200-semi-bold: 600 1.88rem/1.88rem "Poppins";
-$display-200-bold: 700 1.88rem/1.88rem "Poppins";
+$display-200-regular: 400 list.slash(1.88rem, 1.88rem) "Poppins";
+$display-200-medium: 500 list.slash(1.88rem, 1.88rem) "Poppins";
+$display-200-semi-bold: 600 list.slash(1.88rem, 1.88rem) "Poppins";
+$display-200-bold: 700 list.slash(1.88rem, 1.88rem) "Poppins";
 
-$display-100-regular: 400 1.5rem/1.5rem "Poppins";
-$display-100-medium: 500 1.5rem/1.5rem "Poppins";
-$display-100-semi-bold: 600 1.5rem/1.5rem "Poppins";
-$display-100-bold: 700 1.5rem/1.5rem "Poppins";
+$display-100-regular: 400 list.slash(1.5rem, 1.5rem) "Poppins";
+$display-100-medium: 500 list.slash(1.5rem, 1.5rem) "Poppins";
+$display-100-semi-bold: 600 list.slash(1.5rem, 1.5rem) "Poppins";
+$display-100-bold: 700 list.slash(1.5rem, 1.5rem) "Poppins";
 
-$body-500-regular: 400 1.25rem/1.875rem "Inter";
-$body-500-medium: 500 1.25rem/1.875rem "Inter";
-$body-500-semi-bold: 600 1.25rem/1.875rem "Inter";
-$body-500-bold: 700 1.25rem/1.875rem "Inter";
+$body-500-regular: 400 list.slash(1.25rem, 1.875rem) "Inter";
+$body-500-medium: 500 list.slash(1.25rem, 1.875rem) "Inter";
+$body-500-semi-bold: 600 list.slash(1.25rem, 1.875rem) "Inter";
+$body-500-bold: 700 list.slash(1.25rem, 1.875rem) "Inter";
 
-$body-400-regular: 400 1.12rem/1.75rem "Inter";
-$body-400-medium: 500 1.12rem/1.75rem "Inter";
-$body-400-semi-bold: 600 1.12rem/1.75rem "Inter";
-$body-400-bold: 700 1.12rem/1.75rem "Inter";
+$body-400-regular: 400 list.slash(1.12rem, 1.75rem) "Inter";
+$body-400-medium: 500 list.slash(1.12rem, 1.75rem) "Inter";
+$body-400-semi-bold: 600 list.slash(1.12rem, 1.75rem) "Inter";
+$body-400-bold: 700 list.slash(1.12rem, 1.75rem) "Inter";
 
-$body-300-regular: 400 1rem/1.5rem "Inter";
-$body-300-medium: 500 1rem/1.5rem "Inter";
-$body-300-semi-bold: 600 1rem/1.5rem "Inter";
-$body-300-bold: 700 1rem/1.5rem "Inter";
+$body-300-regular: 400 list.slash(1rem, 1.5rem) "Inter";
+$body-300-medium: 500 list.slash(1rem, 1.5rem) "Inter";
+$body-300-semi-bold: 600 list.slash(1rem, 1.5rem) "Inter";
+$body-300-bold: 700 list.slash(1rem, 1.5rem) "Inter";
 
-$body-200-regular: 400 0.88rem/1.25rem "Inter";
-$body-200-medium: 500 0.88rem/1.25rem "Inter";
-$body-200-semi-bold: 600 0.88rem/1.25rem "Inter";
-$body-200-bold: 700 0.88rem/1.25rem "Inter";
+$body-200-regular: 400 list.slash(0.88rem, 1.25rem) "Inter";
+$body-200-medium: 500 list.slash(0.88rem, 1.25rem) "Inter";
+$body-200-semi-bold: 600 list.slash(0.88rem, 1.25rem) "Inter";
+$body-200-bold: 700 list.slash(0.88rem, 1.25rem) "Inter";
 
-$body-100-regular: 400 0.75rem/1.125rem "Inter";
-$body-100-medium: 500 0.75rem/1.125rem "Inter";
-$body-100-semi-bold: 600 0.75rem/1.125rem "Inter";
-$body-100-bold: 700 0.75rem/1.125rem "Inter";
+$body-100-regular: 400 list.slash(0.75rem, 1.125rem) "Inter";
+$body-100-medium: 500 list.slash(0.75rem, 1.125rem) "Inter";
+$body-100-semi-bold: 600 list.slash(0.75rem, 1.125rem) "Inter";
+$body-100-bold: 700 list.slash(0.75rem, 1.125rem) "Inter";
 
 // Function to extract the font size from the variable
 @function get-font-size($font-variable) {


### PR DESCRIPTION
The code has been adjusted to ensure typography values in the tokens library are compatible with utility functions for extracting font size and line height. This was done by using the `list.slash` function from the `sass:list` module for defining these typography values. Now, the font size and line height can be correctly extracted by the utils.