### PR TITLE
Add box-sizing to table cells and improve radio button animation

### DIFF
--- a/.changeset/unlucky-stingrays-relate.md
+++ b/.changeset/unlucky-stingrays-relate.md
@@ -1,0 +1,5 @@
+---
+"@destinygg/libstiny": patch
+---
+
+Improved radio animation. Fixed table cell height. Fixed Input docs

--- a/docs/stories/input.stories.tsx
+++ b/docs/stories/input.stories.tsx
@@ -50,7 +50,7 @@ export const Select: Story = {
     >
       <label>{args.label}</label>
       <div className="input__area">
-        <div className="input__area__prefix">https://</div>
+        <div className="input__prefix">https://</div>
 
         <div className="input__container">
           <select disabled={args.disabled}>

--- a/lib/components/radio.scss
+++ b/lib/components/radio.scss
@@ -4,6 +4,17 @@
 @use "../tokens/shadows" as *;
 @use "../tokens/typography" as *;
 
+@keyframes radio-in {
+  0% {
+    height: 0;
+    width: 0;
+  }
+  100% {
+    height: 0.625rem;
+    width: 0.625rem;
+  }
+}
+
 .radio {
   appearance: none;
   position: relative;
@@ -21,6 +32,17 @@
     cursor: pointer;
   }
 
+  &::after {
+    content: "";
+    width: 0;
+    height: 0;
+    top: 50%;
+    left: 50%;
+    position: absolute;
+    border-radius: $semantic-radii-pill;
+    transform: translate(-50%, -50%);
+  }
+
   &:checked {
     border: 1px solid $radio-indicator-selected-rest;
 
@@ -30,16 +52,9 @@
     }
 
     &::after {
-      content: "";
-      border-radius: $semantic-radii-pill;
-      transition: $transition-default;
-      position: absolute;
       height: 0.625rem;
       width: 0.625rem;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-
+      animation: radio-in 150ms ease-in-out;
       background-color: $radio-indicator-selected-rest;
     }
 

--- a/lib/components/table.scss
+++ b/lib/components/table.scss
@@ -16,6 +16,7 @@
     td {
       height: $table-cell-height;
       padding: $table-cell-padding-vertical $table-cell-padding-horizontal;
+      box-sizing: border-box;
     }
 
     th {


### PR DESCRIPTION
Set box-sizing to border-box for table cells to ensure consistent padding and border behavior. Fixed Input documentation. Introduced `radio-in` keyframe animation for smoother radio button transitions and added initial dimensions to the radio button's ::after element.